### PR TITLE
feat: implement RedisConfig for caching (fixes #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+explain.txt

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,14 @@
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>com.github.ben-manes.caffeine</groupId>-->
+<!--			<artifactId>caffeine</artifactId>-->
+<!--		</dependency>-->
+		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
 			<version>0.12.6</version>

--- a/src/main/java/com/nishant/AuthKit/config/RedisConfig.java
+++ b/src/main/java/com/nishant/AuthKit/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.nishant.AuthKit.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Using Spring's built-in static factory methods
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.json());
+
+        template.setHashKeySerializer(RedisSerializer.string());
+        template.setHashValueSerializer(RedisSerializer.json());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/nishant/AuthKit/controller/AuthController.java
+++ b/src/main/java/com/nishant/AuthKit/controller/AuthController.java
@@ -2,11 +2,14 @@ package com.nishant.AuthKit.controller;
 
 import com.nishant.AuthKit.dto.AuthResponseDTO;
 import com.nishant.AuthKit.dto.LoginRequestDTO;
+import com.nishant.AuthKit.dto.RefreshTokenRequestDTO;
 import com.nishant.AuthKit.dto.UserRegistrationRequestDTO;
 import com.nishant.AuthKit.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,16 +25,49 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/register")
-    public ResponseEntity<AuthResponseDTO> register(@Valid @RequestBody UserRegistrationRequestDTO request) {
+    public ResponseEntity<AuthResponseDTO> register(
+            @Valid @RequestBody UserRegistrationRequestDTO request,
+            HttpServletRequest httpRequest
+    ) {
+        String ipAddress = httpRequest.getRemoteAddr();
+        String userAgent = httpRequest.getHeader("User-Agent");
+
         log.info("Registration request for username: {}", request.getUsername());
-        AuthResponseDTO response = authService.register(request);
+
+        AuthResponseDTO response = authService.register(request, ipAddress, userAgent);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponseDTO> login(@Valid @RequestBody LoginRequestDTO request) {
+    public ResponseEntity<AuthResponseDTO> login(
+            @Valid @RequestBody LoginRequestDTO request,
+            HttpServletRequest httpRequest
+    ) {
+        String ipAddress = httpRequest.getRemoteAddr();
+        String userAgent = httpRequest.getHeader("User-Agent");
+
         log.info("Login request for username: {}", request.getUsernameOrEmail());
-        AuthResponseDTO response = authService.login(request);
+
+        AuthResponseDTO response = authService.login(request, ipAddress, userAgent);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResponseDTO> refreshToken(
+            @Valid @RequestBody RefreshTokenRequestDTO request,
+            HttpServletRequest httpRequest
+    ) {
+        String ipAddress = httpRequest.getRemoteAddr();
+        String userAgent = httpRequest.getHeader("User-Agent");
+
+        AuthResponseDTO response = authService.refreshToken(request, ipAddress, userAgent);
+        return ResponseEntity.ok(response);
+    }
+
+    public ResponseEntity<Boolean> logout(
+            @Valid @RequestBody RefreshTokenRequestDTO request
+    ) {
+        authService.logout(request.getRefreshToken());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/nishant/AuthKit/controller/AuthController.java
+++ b/src/main/java/com/nishant/AuthKit/controller/AuthController.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,7 +48,7 @@ public class AuthController {
         log.info("Login request for username: {}", request.getUsernameOrEmail());
 
         AuthResponseDTO response = authService.login(request, ipAddress, userAgent);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/refresh")
@@ -64,7 +63,8 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-    public ResponseEntity<Boolean> logout(
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
             @Valid @RequestBody RefreshTokenRequestDTO request
     ) {
         authService.logout(request.getRefreshToken());

--- a/src/main/java/com/nishant/AuthKit/dto/AuthResponseDTO.java
+++ b/src/main/java/com/nishant/AuthKit/dto/AuthResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthResponseDTO {
     private String accessToken;
+    private String refreshToken;
     private String tokenType;
     private Long expiresIn;
     private UserResponseDTO user;

--- a/src/main/java/com/nishant/AuthKit/dto/RefreshToken.java
+++ b/src/main/java/com/nishant/AuthKit/dto/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.nishant.AuthKit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+    private String token;
+    private Long userId;
+    private Instant expiresAt;
+    private Instant createdAt;
+    private String ipAddress;
+    private String userAgent;
+}

--- a/src/main/java/com/nishant/AuthKit/dto/RefreshTokenRequestDTO.java
+++ b/src/main/java/com/nishant/AuthKit/dto/RefreshTokenRequestDTO.java
@@ -1,0 +1,10 @@
+package com.nishant.AuthKit.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequestDTO {
+    @NotBlank(message = "Refresh token is required")
+    private String refreshToken;
+}

--- a/src/main/java/com/nishant/AuthKit/service/AuthService.java
+++ b/src/main/java/com/nishant/AuthKit/service/AuthService.java
@@ -100,6 +100,7 @@ public class AuthService {
         }
     }
 
+    @Transactional
     public AuthResponseDTO refreshToken(RefreshTokenRequestDTO request, String ipAddress, String userAgent) {
         String currRefreshToken = request.getRefreshToken();
 
@@ -123,13 +124,15 @@ public class AuthService {
         return buildAuthResponse(user, accessToken, refreshToken);
     }
 
-    public boolean logout(String refreshToken) {
+    public void logout(String refreshToken) {
         if (refreshToken != null && !refreshToken.isBlank()) {
-            Boolean res = refreshTokenService.deleteRefreshToken(refreshToken);
-            log.info("Successfully logged out and deleted refresh token.");
-            return res;
+            boolean res = refreshTokenService.deleteRefreshToken(refreshToken);
+            if (res) {
+                log.info("Successfully logged out and deleted refresh token.");
+            } else {
+                log.warn("Logout called but refresh token was not found in Redis.");
+            }
         }
-        return false;
     }
 
 //    public void logoutAllDevices(Long userId) {}

--- a/src/main/java/com/nishant/AuthKit/service/AuthService.java
+++ b/src/main/java/com/nishant/AuthKit/service/AuthService.java
@@ -1,9 +1,6 @@
 package com.nishant.AuthKit.service;
 
-import com.nishant.AuthKit.dto.AuthResponseDTO;
-import com.nishant.AuthKit.dto.LoginRequestDTO;
-import com.nishant.AuthKit.dto.UserRegistrationRequestDTO;
-import com.nishant.AuthKit.dto.UserResponseDTO;
+import com.nishant.AuthKit.dto.*;
 import com.nishant.AuthKit.entity.Role;
 import com.nishant.AuthKit.entity.User;
 import com.nishant.AuthKit.exception.EmailAlreadyExistsException;
@@ -20,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Service
@@ -31,12 +29,13 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * Register Method for AuthService
      */
     @Transactional
-    public AuthResponseDTO register(UserRegistrationRequestDTO request) {
+    public AuthResponseDTO register(UserRegistrationRequestDTO request, String ipAddress, String userAgent) {
         log.info("Attempting to register user: {}", request.getUsername());
 
         if (userRepository.findByUsername(request.getUsername()).isPresent()) {
@@ -61,15 +60,16 @@ public class AuthService {
         User savedUser = userRepository.save(createdUser);
         log.info("User registered successfully: {}", savedUser.getUsername());
 
-        String token = jwtService.generateToken(createdUser);
-        return buildAuthResponse(savedUser, token);
+        String accessToken = jwtService.generateToken(createdUser);
+        String refreshToken = refreshTokenService.createRefreshToken(savedUser.getId(), ipAddress,userAgent);
+        return buildAuthResponse(savedUser, accessToken, refreshToken);
     }
 
     /**
      * Login Method for AuthService
      */
     @Transactional
-    public AuthResponseDTO login(LoginRequestDTO request) {
+    public AuthResponseDTO login(LoginRequestDTO request, String ipAddress, String userAgent) {
         log.info("Attempting login for: {}", request.getUsernameOrEmail());
         try {
             /**
@@ -89,22 +89,58 @@ public class AuthService {
             user.setLastLoginAt(LocalDateTime.now());
             userRepository.save(user);
 
-            String token = jwtService.generateToken(user);
+            String accessToken = jwtService.generateToken(user);
+            String refreshToken = refreshTokenService.createRefreshToken(user.getId(), ipAddress, userAgent);
 
             log.info("User logged in successfully: {}", user.getUsername());
-            return buildAuthResponse(user, token);
+            return buildAuthResponse(user, accessToken, refreshToken);
         } catch (AuthenticationException e) {
             log.error("Login failed for User: {}", request.getUsernameOrEmail());
             throw new BadCredentialsException("Invalid credentials");
         }
     }
 
+    public AuthResponseDTO refreshToken(RefreshTokenRequestDTO request, String ipAddress, String userAgent) {
+        String currRefreshToken = request.getRefreshToken();
+
+        RefreshToken storedToken = refreshTokenService.findByToken(currRefreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Refresh Token"));
+
+        if (storedToken.getExpiresAt().isBefore(Instant.now())) {
+            refreshTokenService.deleteRefreshToken(currRefreshToken);
+            throw new IllegalArgumentException("Refresh token has expired. Please sign in again");
+        }
+
+        User user = userRepository.findById(storedToken.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User associated with token not found"));
+
+        refreshTokenService.deleteRefreshToken(currRefreshToken);
+
+        String accessToken = jwtService.generateToken(user);
+        String refreshToken = refreshTokenService.createRefreshToken(user.getId(), ipAddress, userAgent);
+
+        log.info("Successfully rotated refresh token for user: {}", user.getUsername());
+        return buildAuthResponse(user, accessToken, refreshToken);
+    }
+
+    public boolean logout(String refreshToken) {
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            Boolean res = refreshTokenService.deleteRefreshToken(refreshToken);
+            log.info("Successfully logged out and deleted refresh token.");
+            return res;
+        }
+        return false;
+    }
+
+//    public void logoutAllDevices(Long userId) {}
+
     /**
      * Helper method to build AuthResponseDTO
      */
-    private AuthResponseDTO buildAuthResponse(User user, String token) {
+    private AuthResponseDTO buildAuthResponse(User user, String accessToken, String refreshToken) {
         AuthResponseDTO auth = AuthResponseDTO.builder()
-                .accessToken(token)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .tokenType("Bearer")
                 .expiresIn(jwtService.getJwtExpiration())
                 .user(mapToUserResponseDTO(user))

--- a/src/main/java/com/nishant/AuthKit/service/RefreshTokenService.java
+++ b/src/main/java/com/nishant/AuthKit/service/RefreshTokenService.java
@@ -1,0 +1,90 @@
+package com.nishant.AuthKit.service;
+
+import com.nishant.AuthKit.dto.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RefreshTokenService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    public String createRefreshToken(Long userId, String ipAddress, String userAgent) {
+        String token = UUID.randomUUID().toString();
+        Instant createdAt = Instant.now();
+        Instant expiresAt = createdAt.plusMillis(refreshTokenExpiration);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token(token)
+                .userId(userId)
+                .expiresAt(expiresAt)
+                .createdAt(createdAt)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .build();
+
+        String key = "refresh_token:" + token;
+
+        redisTemplate.opsForValue().set(
+                key,
+                refreshToken,
+                refreshTokenExpiration,
+                TimeUnit.MILLISECONDS
+        );
+
+        log.info("Created refresh token for User: {}", userId);
+        return token;
+    }
+
+    public Optional<RefreshToken> findByToken(String token) {
+        String key = "refresh_token:" + token;
+        RefreshToken refreshToken = (RefreshToken) redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(refreshToken);
+    }
+
+    public boolean validateRefreshToken(String token, Long userId) {
+        Optional<RefreshToken> storedTokenOpt = findByToken(token);
+
+        if (storedTokenOpt.isEmpty()) {
+            log.warn("Refresh token not found in Redis: {}", token);
+            return false;
+        }
+
+        RefreshToken storedToken = storedTokenOpt.get();
+
+        if (!storedToken.getUserId().equals(userId)) {
+            log.warn("User ID mismatch for refresh token. Expected: {}, Actual: {}", storedToken.getUserAgent(), userId);
+            return false;
+        }
+
+        if (storedToken.getExpiresAt().isBefore(Instant.now())) {
+            log.warn("Refresh token expired for user: {}", userId);
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean deleteRefreshToken(String token) {
+        String key = "refresh_token:" + token;
+        Boolean res = redisTemplate.delete(key);
+        log.info("Deleted refresh token from Redis for {}", token);
+        return res;
+    }
+
+//    public void deleteAllUserTokens(Long userId) {
+//
+//    }
+}

--- a/src/main/java/com/nishant/AuthKit/service/RefreshTokenService.java
+++ b/src/main/java/com/nishant/AuthKit/service/RefreshTokenService.java
@@ -58,14 +58,14 @@ public class RefreshTokenService {
         Optional<RefreshToken> storedTokenOpt = findByToken(token);
 
         if (storedTokenOpt.isEmpty()) {
-            log.warn("Refresh token not found in Redis: {}", token);
+            log.warn("Refresh token not found in Redis: token ending: ...{})", token.substring(token.length() - 4));
             return false;
         }
 
         RefreshToken storedToken = storedTokenOpt.get();
 
         if (!storedToken.getUserId().equals(userId)) {
-            log.warn("User ID mismatch for refresh token. Expected: {}, Actual: {}", storedToken.getUserAgent(), userId);
+            log.warn("User ID mismatch for refresh token. Expected: {}, Actual: {}", storedToken.getUserId(), userId);
             return false;
         }
 
@@ -79,8 +79,8 @@ public class RefreshTokenService {
 
     public boolean deleteRefreshToken(String token) {
         String key = "refresh_token:" + token;
-        Boolean res = redisTemplate.delete(key);
-        log.info("Deleted refresh token from Redis for {}", token);
+        boolean res = redisTemplate.delete(key);
+        log.info("Deleted refresh token from Redis (token ending: ...{})", token.substring(token.length() - 4));
         return res;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,8 +12,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
-spring.data.redis.host=localhost
-spring.data.redis.port=6379
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
 #spring.data.redis.password=${REDIS_PASSWORD}
 
 jwt.refresh-token-expiration=604800000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 #spring.data.redis.password=${REDIS_PASSWORD}
+
+jwt.refresh-token-expiration=604800000


### PR DESCRIPTION
## Description
Added `RedisConfig` to handle caching setup.
Added `RefreshTokenService` to handle token refresh.

## Related Issue
Closes #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token refresh endpoint to extend sessions
  * Logout endpoint to invalidate refresh tokens
  * Responses now include a refresh token alongside the access token
  * Session tracking enhanced with client IP and user-agent

* **Infrastructure**
  * Redis-backed storage for refresh tokens with configurable expiration
  * Spring Boot caching support added

* **Configuration**
  * Redis host/port and refresh-token expiration made configurable via properties
<!-- end of auto-generated comment: release notes by coderabbit.ai -->